### PR TITLE
fix license name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+The ISC License
 
 Copyright © 2016, Michael Ackley <ackleymi@gmail.com>
 


### PR DESCRIPTION
The license text corresponds to the ISC license, not the MIT license. Compare: [MIT](http://choosealicense.com/licenses/mit/) vs [ISC](http://choosealicense.com/licenses/isc/).