### PR TITLE
Rename interval constants

### DIFF
--- a/history.go
+++ b/history.go
@@ -8,11 +8,11 @@ import (
 
 const (
 	// Day interval.
-	Day = "d"
+	IntervalDaily = "d"
 	// Week interval.
-	Week = "w"
+	IntervalWeekly = "w"
 	// Month interval.
-	Month = "m"
+	IntervalMonthly = "m"
 
 	// Dividend constant.
 	Dividend = "DIVIDEND"

--- a/history_test.go
+++ b/history_test.go
@@ -12,7 +12,7 @@ func Test_GetHistory(t *testing.T) {
 	defer s.Close()
 	HistoryURL = s.URL
 
-	bars, err := GetHistory("TWTR", Datetime{}, Datetime{}, Day)
+	bars, err := GetHistory("TWTR", Datetime{}, Datetime{}, IntervalDaily)
 	assert.Nil(t, err)
 
 	// result should be a TWTR bar.


### PR DESCRIPTION
  Renamed the interval constants to match the README:
    finance.Day   => finance.IntervalDaily
    finance.Week  => finance.IntervalWeekly
    finance.Month => finance.IntervalMonthly