### PR TITLE
Remove imported and not used time

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/FlashBoys/go-finance"
 )


### PR DESCRIPTION
Fix Quote history example, current it fails.
```
$ go run main.go
# command-line-arguments
./main.go:5:2: imported and not used: "time"
```